### PR TITLE
Update operandBindInfo instance

### DIFF
--- a/deploy/olm-catalog/ibm-metering-operator/3.6.0/ibm-metering-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-metering-operator/3.6.0/ibm-metering-operator.v3.6.0.clusterserviceversion.yaml
@@ -160,12 +160,11 @@ metadata:
             "operand": "ibm-metering-operator",
             "registry": "common-service",
             "description": "Binding information that should be accessible to metering adopters",
-            "bindings": [
-              {
-                "scope": "public",
+            "bindings": {
+              "public": {
                 "secret": "icp-metering-api-secret"
               }
-            ]
+            }
           }
         }
       ]


### PR DESCRIPTION
Refactor the operandBindInfo `bindings`
## Background 
The `bindings` in the `OperandBindInfo` and `OperandRequest` is not actually a list, it only includes a `public` scope and a `private ` scope.  Could we use a dual object to replace the list? 
For example,
Change
```
      "spec": {
        "operand": "ibm-licensing-operator",
        "registry": "common-service",
        "description": "Binding information that should be accessible to licensing adopters",
        "bindings": [
          {
            "scope": "public",
            "secret": "ibm-licensing-token"
          }
        ]
      }
```
to
```
      "spec": {
        "operand": "ibm-licensing-operator",
        "registry": "common-service",
        "description": "Binding information that should be accessible to licensing adopters",
        "bindings": {
            "public": {
                 "secret": "ibm-licensing-token",
                 "comfigmap": "ibm-licensing-cm"
              },
            "private": {
                 "secret": "ibm-licensing-token-private",
                 "comfigmap": "ibm-licensing-cm-private"
              }
          }
        ]
      }
```